### PR TITLE
Chart version updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,22 @@ jobs:
       - run: helm package ./charts/atlantis
       - run: |
           aws s3 cp atlantis-*.tgz s3://procore-helm-charts/
+
+# default filters for jobs so we only run on tags
+defaults: &defaults
+  filters:
+    branches:
+      ignore: /.*/
+    tags:
+      only: /^\d+\.\d+\.\d+(?:-.+)?$/
+
 workflows:
   build:
     jobs:
-      - chart_version
+      - chart_version:
+          <<: *defaults
       - chart_to_s3:
+          <<: *defaults
           context: helm-package-release
           requires:
             - chart_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
       - run: |
           aws s3 cp atlantis-*.tgz s3://procore-helm-charts/
 workflows:
-  version: 2.1
   build:
     jobs:
       - chart_version

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.16.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.12.11
+version: 3.12.12-procore-0.0.1
 keywords:
 - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
The goal of this PR is to synchronize the chart version with a git tag. This will allow us to parameterize the tag in spinnaker, so we don't have to enter it multiple times.
* Adjust the CircleCI pipeline so it only runs the chart build/push on tags only.
* Bump the chart version from `3.12.11` to `3.12.12-procore-0.0.1`