### PR TITLE
CPO-506 Silence allowlist errors

### DIFF
--- a/charts/atlantis/stages/production/values.yaml
+++ b/charts/atlantis/stages/production/values.yaml
@@ -54,6 +54,7 @@ environment:
 #   ATLANTIS_ATLANTIS_URL: http://atlantis.production.procoretech.com/
 #   ATLANTIS_LOG_LEVEL: debug
 #   ATLANTIS_GH_ORG: procore
+#   ATLANTIS_SILENCE_ALLOWLIST_ERRORS: true
 
 # github: null
 

--- a/charts/atlantis/stages/staging/values.yaml
+++ b/charts/atlantis/stages/staging/values.yaml
@@ -54,6 +54,7 @@ environment:
   ATLANTIS_ATLANTIS_URL: http://atlantis.procoretech-qa.com/
   ATLANTIS_LOG_LEVEL: debug
   ATLANTIS_GH_ORG: procore
+  ATLANTIS_SILENCE_ALLOWLIST_ERRORS: true
 
 github: null
 


### PR DESCRIPTION
https://procoretech.atlassian.net/browse/CPO-506
- Use server option `--silence-allowlist-errors` to keep Atlantis from commenting on PRs outside of the allowlist.