### PR TITLE
sref-504-Adding data-tribe repo on whitelist

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -9,7 +9,7 @@
 # Replace this with your own repo whitelist:
 # For multiple repos use comma separated values:
 # github.com/myorg/repo1,github.com/myorg/repo2
-orgWhitelist: github.com/procore/terraform-ml,github.com/procore/terraform-infra,github.com/procore/terraform-snowflake
+orgWhitelist: github.com/procore/terraform-ml,github.com/procore/terraform-infra,github.com/procore/terraform-snowflake,github.com/procore/terraform-data-tribe
 # logLevel: "debug"
 
 # If using GitHub, specify like the following:


### PR DESCRIPTION
As part of putting global Atlantis on Data Training account, we need to add data-tribe repo on orgWhitelist.

Based on request:
https://procoretech.atlassian.net/browse/SREF-504