### PR TITLE
CPP 61 - atlantis terraform cloud docker image bump

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.16.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.12.12-procore-0.0.17
+version: 3.12.12-procore-0.0.18
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -85,7 +85,7 @@ serviceAccountSecrets:
 # use the Procore custom Atlantis docker image
 image:
   repository: quay.io/procoredevops/atlantis-helm-chart
-  tag: procore-atlantis-v0.17.0-0.0.4
+  tag: procore-atlantis-v0.17.0-0.0.5
   pullPolicy: IfNotPresent
 
 ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Fixes missing release for docker image build and version bump
Updates chart version to capture new image version