### PR TITLE
CPP-62 - bump version for image tag

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -85,7 +85,7 @@ serviceAccountSecrets:
 # use the Procore custom Atlantis docker image
 image:
   repository: quay.io/procoredevops/atlantis-helm-chart
-  tag: procore-atlantis-v0.17.0-0.0.6
+  tag: procore-atlantis-v0.17.5-0.0.6
   pullPolicy: IfNotPresent
 
 ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
I forgot to bump the atlantis tag version