### PR TITLE
add new kubernetes cluster configuration repo to allowlist

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -9,7 +9,7 @@
 # Replace this with your own repo whitelist:
 # For multiple repos use comma separated values:
 # github.com/myorg/repo1,github.com/myorg/repo2
-orgWhitelist: github.com/procore/terraform-ml,github.com/procore/terraform-infra,github.com/procore/terraform-snowflake,github.com/procore/terraform-data-tribe
+orgWhitelist: github.com/procore/terraform-ml,github.com/procore/terraform-infra,github.com/procore/terraform-snowflake,github.com/procore/terraform-data-tribe,github.com/procore/orchestration-platform
 # logLevel: "debug"
 
 # If using GitHub, specify like the following:


### PR DESCRIPTION
Team Orchestration is migrating cluster terraform to a new repo named `orchestration-platform`
https://procoretech.atlassian.net/browse/CPO-1322